### PR TITLE
Updated to .NET10 & BUnit2.x

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -43,7 +43,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 10.0.x
     - name: dotnet pack
       run: dotnet pack --configuration Release --include-symbols --include-source /p:PackageVersion='${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}' -o nupkg FluentAssertions.BUnit
     - name: Push to NuGet Feed

--- a/FluentAssertions.BUnit.Tests/AssertionExtensions/ElementShould.razor
+++ b/FluentAssertions.BUnit.Tests/AssertionExtensions/ElementShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -10,6 +10,6 @@
             
         var elementAssertions = element.Should();
         
-        elementAssertions.Should().BeOfType<ElementAssertions>();
+        elementAssertions.GetType().Should().Be(typeof(ElementAssertions));
     }
 }

--- a/FluentAssertions.BUnit.Tests/AssertionExtensions/RenderedFragmentShould.razor
+++ b/FluentAssertions.BUnit.Tests/AssertionExtensions/RenderedFragmentShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -9,6 +9,7 @@
             
         var renderedFragmentAssertion = renderedFragment.Should();
         
-        renderedFragmentAssertion.Should().BeOfType<RenderedFragmentAssertions>();
+        renderedFragmentAssertion.GetType().IsGenericType.Should().BeTrue();
+        renderedFragmentAssertion.GetType().GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 }

--- a/FluentAssertions.BUnit.Tests/BUnitExtensions/AsElementShould.razor
+++ b/FluentAssertions.BUnit.Tests/BUnitExtensions/AsElementShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     

--- a/FluentAssertions.BUnit.Tests/BUnitExtensions/FindAllByDataTestClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/BUnitExtensions/FindAllByDataTestClassShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     

--- a/FluentAssertions.BUnit.Tests/BUnitExtensions/FindByDataTestClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/BUnitExtensions/FindByDataTestClassShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     

--- a/FluentAssertions.BUnit.Tests/BUnitExtensions/FindByDataTestIdShould.razor
+++ b/FluentAssertions.BUnit.Tests/BUnitExtensions/FindByDataTestIdShould.razor
@@ -1,4 +1,4 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAltTextShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAltTextShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().HaveAltText("Logo");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveAltText("Logo");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -29,9 +32,9 @@
             .Should().HaveAltText("Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"alt\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"alt\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -40,9 +43,9 @@
             .Should().HaveAltText("Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"alt\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"alt\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -51,9 +54,9 @@
             .Should().HaveAltText("Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\", but found \"Log\".");
+            .And.Message.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\", but found \"Log\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -62,6 +65,6 @@
             .Should().HaveAltText("Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
+            .And.Message.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAriaLabelShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAriaLabelShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().HaveAriaLabel("Home Page");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveAriaLabel("Home Page");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -29,9 +32,9 @@
             .Should().HaveAriaLabel("Home Page");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"aria-label\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"aria-label\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -40,9 +43,9 @@
             .Should().HaveAriaLabel("Home Page", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"aria-label\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"aria-label\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -51,9 +54,9 @@
             .Should().HaveAriaLabel("Home Page");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"aria-label\" attribute to have value \"Home Page\", but found \"Home\".");
+            .And.Message.Should().Be("Expected IElement \"aria-label\" attribute to have value \"Home Page\", but found \"Home\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -62,6 +65,6 @@
             .Should().HaveAriaLabel("Home Page", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"aria-label\" attribute to have value \"Home Page\" because this is very important to Steve, but found \"Home\".");
+            .And.Message.Should().Be("Expected IElement \"aria-label\" attribute to have value \"Home Page\" because this is very important to Steve, but found \"Home\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAttributeShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveAttributeShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().HaveAttribute("alt", "Logo");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveAttribute("alt", "Logo");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -29,9 +32,9 @@
             .Should().HaveAttribute("alt", "Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"alt\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"alt\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -40,9 +43,9 @@
             .Should().HaveAttribute("alt", "Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"alt\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"alt\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -51,9 +54,9 @@
             .Should().HaveAttribute("alt", "Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\", but found \"Log\".");
+            .And.Message.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\", but found \"Log\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -62,6 +65,6 @@
             .Should().HaveAttribute("alt", "Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
+            .And.Message.Should().Be("Expected IElement \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveChildMarkupShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveChildMarkupShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed_WhenMatchingByString()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().HaveChildMarkup("<h1>Test</h1>");
     }
-    
+
     [Fact]
     public void Succeed_WhenMatchingByRenderFragment()
     {
@@ -18,7 +18,7 @@
             .AsElement()
             .Should().HaveChildMarkup(@<h1>Test</h1>);
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByString()
     {
@@ -26,9 +26,12 @@
             .AsElement()
             .Should().HaveChildMarkup("<h1>Test</h1>");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByRenderFragment()
     {
@@ -36,20 +39,23 @@
             .AsElement()
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupIsNull_AndMatchingByString()
     {
         Action aut = () => Render(@<button></button>)
             .AsElement()
-            .Should().HaveChildMarkup("<h1>Test</h1>");;
+            .Should().HaveChildMarkup("<h1>Test</h1>"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupIsNull_AndMatchingByRenderFragment()
     {
@@ -58,20 +64,20 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupIsNull_AndMatchingByString()
     {
         Action aut = () => Render(@<button></button>)
             .AsElement()
-            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve");;
+            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupIsNull_AndMatchingByRenderFragment()
     {
@@ -80,7 +86,7 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
     }
 
     [Fact]
@@ -88,12 +94,12 @@
     {
         Action aut = () => Render(@<button><h2>Test</h2></button>)
             .AsElement()
-            .Should().HaveChildMarkup("<h1>Test</h1>");;
+            .Should().HaveChildMarkup("<h1>Test</h1>"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupDoesNotMatch_AndMatchingByRenderFragment()
     {
@@ -102,20 +108,20 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByString()
     {
         Action aut = () => Render(@<button><h2>Test</h2></button>)
             .AsElement()
-            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve");;
+            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByRenderFragment()
     {
@@ -124,6 +130,6 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IElement to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveClassShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -21,7 +21,10 @@
             .AsElement()
             .Should().HaveClass("btn");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -32,7 +35,7 @@
             .Should().HaveClass("btn");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {empty} to contain \"btn\".");
+            .And.Message.Should().Be("Expected Subject.ClassList {empty} to contain \"btn\".");
     }
     
     [Fact]
@@ -43,7 +46,7 @@
             .Should().HaveClass("btn", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {empty} to contain \"btn\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected Subject.ClassList {empty} to contain \"btn\" because this is very important to Steve.");
     }
     
     [Fact]
@@ -54,7 +57,7 @@
             .Should().HaveClass("btn");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\".");
+            .And.Message.Should().Be("Expected Subject.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\".");
     }
     
     [Fact]
@@ -65,6 +68,6 @@
             .Should().HaveClass("btn", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected Subject.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveDataTestClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveDataTestClassShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveDataTestClass("magic-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveDataTestClass("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"data-test-class\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"data-test-class\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveDataTestClass("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"data-test-class\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"data-test-class\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveDataTestClass("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"data-test-class\" attribute to have value \"magic-button\", but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IElement \"data-test-class\" attribute to have value \"magic-button\", but found \"magic-btn\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveDataTestClass("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"data-test-class\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IElement \"data-test-class\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveDataTestIdShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveDataTestIdShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveDataTestId("magic-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveDataTestId("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"data-test-id\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"data-test-id\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveDataTestId("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"data-test-id\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"data-test-id\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveDataTestId("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"data-test-id\" attribute to have value \"magic-button\", but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IElement \"data-test-id\" attribute to have value \"magic-button\", but found \"magic-btn\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveDataTestId("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"data-test-id\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IElement \"data-test-id\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveHrefShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveHrefShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"href\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"href\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"href\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"href\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\", but found \"#\".");
+            .And.Message.Should().Be("Expected IElement \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\", but found \"#\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\" because this is very important to Steve, but found \"#\".");
+            .And.Message.Should().Be("Expected IElement \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\" because this is very important to Steve, but found \"#\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveIdShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveIdShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveId("special-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveId("special-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"id\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"id\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveId("special-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"id\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"id\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveId("special-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"id\" attribute to have value \"special-button\", but found \"special-btn\".");
+            .And.Message.Should().Be("Expected IElement \"id\" attribute to have value \"special-button\", but found \"special-btn\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveId("special-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"id\" attribute to have value \"special-button\" because this is very important to Steve, but found \"special-btn\".");
+            .And.Message.Should().Be("Expected IElement \"id\" attribute to have value \"special-button\" because this is very important to Steve, but found \"special-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveMarkupShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveMarkupShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -26,7 +26,10 @@
             .AsElement()
             .Should().HaveMarkup("<button><h1>Test</h1></button>");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -36,7 +39,10 @@
             .AsElement()
             .Should().HaveMarkup(@<button><h1>Test</h1></button>);
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -47,7 +53,7 @@
             .Should().HaveMarkup("<button><h1>Test</h1></button>");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be($"Expected IElement markup \"<button><h1>Test</h1></button>\", but found \"{Environment.NewLine}<button>{Environment.NewLine}  <h2>Test</h2>{Environment.NewLine}</button>\".");
+            .And.Message.Should().Be("Expected IElement markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
     }
 
     [Fact]
@@ -58,7 +64,7 @@
             .Should().HaveMarkup(@<button><h1>Test</h1></button>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be($"Expected IElement markup \"<button><h1>Test</h1></button>\", but found \"{Environment.NewLine}<button>{Environment.NewLine}  <h2>Test</h2>{Environment.NewLine}</button>\".");
+            .And.Message.Should().Be("Expected IElement markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
     }
     
     [Fact]
@@ -69,7 +75,7 @@
             .Should().HaveMarkup("<button><h1>Test</h1></button>", "this is very important to {0}", "Steve");;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be($"Expected IElement markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"{Environment.NewLine}<button>{Environment.NewLine}  <h2>Test</h2>{Environment.NewLine}</button>\".");
+            .And.Message.Should().Be("Expected IElement markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
     }
     
     [Fact]
@@ -80,6 +86,6 @@
             .Should().HaveMarkup(@<button><h1>Test</h1></button>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be($"Expected IElement markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"{Environment.NewLine}<button>{Environment.NewLine}  <h2>Test</h2>{Environment.NewLine}</button>\".");
+            .And.Message.Should().Be("Expected IElement markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveRelShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveRelShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -22,7 +22,10 @@
             .AsElement()
             .Should().HaveRel(expected);
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -33,7 +36,7 @@
             .Should().HaveRel("nofollow");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"rel\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"rel\", but found <null>.");
     }
     
     [Fact]
@@ -44,7 +47,7 @@
             .Should().HaveRel("nofollow", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"rel\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"rel\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -55,7 +58,7 @@
             .Should().HaveRel("noopener");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"rel\" [{\"nofollow\"}] to contain \"noopener\".");
+            .And.Message.Should().Be("Expected IElement \"rel\" [{\"nofollow\"}] to contain \"noopener\".");
     }
     
     [Fact]
@@ -66,6 +69,6 @@
             .Should().HaveRel("noopener", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"rel\" [{\"nofollow\"}] to contain \"noopener\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected IElement \"rel\" [{\"nofollow\"}] to contain \"noopener\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveSrcShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveSrcShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveSrc("/logo.png");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveSrc("/logo.png");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"src\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"src\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveSrc("/logo.png", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"src\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"src\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveSrc("/logo.png");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"src\" attribute to have value \"/logo.png\", but found \"/loog.png\".");
+            .And.Message.Should().Be("Expected IElement \"src\" attribute to have value \"/logo.png\", but found \"/loog.png\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveSrc("/logo.png", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"src\" attribute to have value \"/logo.png\" because this is very important to Steve, but found \"/loog.png\".");
+            .And.Message.Should().Be("Expected IElement \"src\" attribute to have value \"/logo.png\" because this is very important to Steve, but found \"/loog.png\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTagShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTagShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().HaveTag("button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveTag("button");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -29,9 +32,9 @@
             .Should().HaveTag("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"tag\" to be \"button\", but found \"div\".");
+            .And.Message.Should().Be("Expected IElement \"tag\" to be \"button\", but found \"div\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenTagNotMatchExpected_AndShouldIncludeBecauseMessage()
     {
@@ -40,6 +43,6 @@
             .Should().HaveTag("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"tag\" to be \"button\" because this is very important to Steve, but found \"div\".");
+            .And.Message.Should().Be("Expected IElement \"tag\" to be \"button\" because this is very important to Steve, but found \"div\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTargetShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTargetShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveTarget("_blank");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveTarget("_blank");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"target\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"target\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveTarget("_blank", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"target\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"target\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveTarget("_blank");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"target\" attribute to have value \"_blank\", but found \"_self\".");
+            .And.Message.Should().Be("Expected IElement \"target\" attribute to have value \"_blank\", but found \"_self\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveTarget("_blank", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"target\" attribute to have value \"_blank\" because this is very important to Steve, but found \"_self\".");
+            .And.Message.Should().Be("Expected IElement \"target\" attribute to have value \"_blank\" because this is very important to Steve, but found \"_self\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTitleShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTitleShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveTitle("GitHub Repo");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveTitle("GitHub Repo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"title\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"title\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveTitle("GitHub Repo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"title\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"title\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveTitle("GitHub Repo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"title\" attribute to have value \"GitHub Repo\", but found \"GH Repo\".");
+            .And.Message.Should().Be("Expected IElement \"title\" attribute to have value \"GitHub Repo\", but found \"GH Repo\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveTitle("GitHub Repo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"title\" attribute to have value \"GitHub Repo\" because this is very important to Steve, but found \"GH Repo\".");
+            .And.Message.Should().Be("Expected IElement \"title\" attribute to have value \"GitHub Repo\" because this is very important to Steve, but found \"GH Repo\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/HaveTypeShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -18,7 +18,10 @@
             .AsElement()
             .Should().HaveType("button");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
     
     [Fact]
@@ -29,7 +32,7 @@
             .Should().HaveType("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"type\", but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"type\", but found <null>.");
     }
     
     [Fact]
@@ -40,7 +43,7 @@
             .Should().HaveType("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement to have attribute \"type\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IElement to have attribute \"type\" because this is very important to Steve, but found <null>.");
     }
     
     [Fact]
@@ -51,7 +54,7 @@
             .Should().HaveType("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"type\" attribute to have value \"button\", but found \"reset\".");
+            .And.Message.Should().Be("Expected IElement \"type\" attribute to have value \"button\", but found \"reset\".");
     }
     
     [Fact]
@@ -62,6 +65,6 @@
             .Should().HaveType("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IElement \"type\" attribute to have value \"button\" because this is very important to Steve, but found \"reset\".");
+            .And.Message.Should().Be("Expected IElement \"type\" attribute to have value \"button\" because this is very important to Steve, but found \"reset\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeAssignableToShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeAssignableToShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenAssignable()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().BeAssignableTo<IElement>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotAssignable()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeNullShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeNullShould.razor
@@ -1,16 +1,16 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenNull()
     {
         IElement e = null;
-        
+
         e.Should().BeNull();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotNull()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeOfTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeOfTypeShould.razor
@@ -1,24 +1,24 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenOfType()
     {
         var element = Render(@<img src="/logo.png" alt="Logo">)
             .AsElement();
-        
+
         element
             .Should().BeOfType(element.GetType());
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotOfType()
     {
         Action aut = () => Render(@<img src="/logo.png" alt="Logo">)
             .AsElement()
-            .Should().BeOfType<IRenderedFragment>();
+            .Should().BeOfType<IRenderedComponent<Microsoft.AspNetCore.Components.IComponent>>();
 
         aut.Should().Throw<XunitException>();
     }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeSameAsShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/BeSameAsShould.razor
@@ -1,14 +1,14 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenComparingToSameReference()
     {
         var element = Render(@<img src="/logo.png" alt="Logo">)
             .AsElement();
-        
+
         element
             .Should().BeSameAs(element);
     }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/MatchShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/MatchShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenMatches()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().Match(e => e.Attributes["alt"].Value == "Logo");
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenDoesNotMatch()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeAssignableToShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeAssignableToShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenAssignable()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().NotBeAssignableTo<string>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotAssignable()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeNullShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeNullShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenNotNull()
     {
@@ -10,7 +10,7 @@
             .AsElement()
             .Should().NotBeNull();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNull()
     {
@@ -19,7 +19,7 @@
             IElement element = null;
             element.Should().NotBeNull();
         };
-        
+
         aut.Should().Throw<XunitException>();
     }
 }

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeOfTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeOfTypeShould.razor
@@ -1,16 +1,16 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenOfType()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .AsElement()
-            .Should().NotBeOfType<IRenderedFragment>();
+            .Should().NotBeOfType<IRenderedComponent<Microsoft.AspNetCore.Components.IComponent>>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotOfType()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeSameAsShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/NotBeSameAsShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenComparingToAnotherReference()
     {

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/Readme.md
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/Readme.md
@@ -1,3 +1,3 @@
-> 💡 Note: The functionality that we test here we get from `RenderedFragmentAssertions` inheriting from `ReferenceTypeAssertions<IRenderedFragment, TAssertions>`.
+> 💡 Note: The functionality that we test here we get from `RenderedFragmentAssertions` inheriting from `ReferenceTypeAssertions<IElement, TAssertions>`.
 > 
 > I decided to add some basic tests to explore their API and check it behaves as I expect.

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/SubjectShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/Inherited/SubjectShould.razor
@@ -1,12 +1,12 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void BeSameAsRenderedFragment()
     {
         var element = Render(@<img src="/logo.png" alt="Logo">).AsElement();
-        
+
         var subject = element.Should().Subject;
 
         subject.Should().BeAssignableTo<IElement>().And.BeSameAs(element);

--- a/FluentAssertions.BUnit.Tests/ElementAssertions/NotHaveClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/ElementAssertions/NotHaveClassShould.razor
@@ -1,5 +1,5 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
     
@@ -26,7 +26,10 @@
             .AsElement()
             .Should().NotHaveClass("btn-large");
 
-        andConstraint.Should().BeOfType<AndConstraint<ElementAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        constraintType.GetGenericArguments()[0].Should().BeSameAs(typeof(ElementAssertions));
     }
 
     [Fact]
@@ -37,7 +40,7 @@
             .Should().NotHaveClass("btn-large");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\".");
+            .And.Message.Should().Be("Expected Subject.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\".");
     }
     
     [Fact]
@@ -48,6 +51,6 @@
             .Should().NotHaveClass("btn-large", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected Subject.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected Subject.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/FluentAssertions.BUnit.Tests.csproj
+++ b/FluentAssertions.BUnit.Tests/FluentAssertions.BUnit.Tests.csproj
@@ -1,21 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="bunit" Version="1.2.49" />
-        <PackageReference Include="FluentAssertions" Version="6.0.0" />
-        <PackageReference Include="FluentAssertions.BUnit" Version="0.0.31" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			  <PackageReference Include="bunit" Version="2.0.66" />
+			  <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAltTextShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAltTextShould.razor
@@ -1,22 +1,27 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveAltText("Logo");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveAltText("Logo");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -26,9 +31,9 @@
             .Should().HaveAltText("Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"alt\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"alt\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveAltText("Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"alt\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"alt\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveAltText("Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"alt\" attribute to have value \"Logo\", but found \"Log\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"alt\" attribute to have value \"Logo\", but found \"Log\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveAltText("Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAriaLabelShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAriaLabelShould.razor
@@ -1,22 +1,27 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<a href="#" aria-label="Home Page">Link</a>)
             .Should().HaveAriaLabel("Home Page");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<a href="#" aria-label="Home Page">Link</a>)
             .Should().HaveAriaLabel("Home Page");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -26,9 +31,9 @@
             .Should().HaveAriaLabel("Home Page");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"aria-label\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"aria-label\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveAriaLabel("Home Page", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"aria-label\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"aria-label\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveAriaLabel("Home Page");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"aria-label\" attribute to have value \"Home Page\", but found \"Home\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"aria-label\" attribute to have value \"Home Page\", but found \"Home\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveAriaLabel("Home Page", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"aria-label\" attribute to have value \"Home Page\" because this is very important to Steve, but found \"Home\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"aria-label\" attribute to have value \"Home Page\" because this is very important to Steve, but found \"Home\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAttributeShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveAttributeShould.razor
@@ -1,22 +1,27 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveAttribute("alt", "Logo");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveAttribute("alt", "Logo");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -26,9 +31,9 @@
             .Should().HaveAttribute("alt", "Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"alt\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"alt\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveAttribute("alt", "Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"alt\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"alt\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveAttribute("alt", "Logo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"alt\" attribute to have value \"Logo\", but found \"Log\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"alt\" attribute to have value \"Logo\", but found \"Log\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveAttribute("alt", "Logo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"alt\" attribute to have value \"Logo\" because this is very important to Steve, but found \"Log\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveChildMarkupShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveChildMarkupShould.razor
@@ -1,50 +1,60 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed_WhenMatchingByString()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().HaveChildMarkup("<h1>Test</h1>");
     }
-    
+
     [Fact]
     public void Succeed_WhenMatchingByRenderFragment()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().HaveChildMarkup(@<h1>Test</h1>);
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByString()
     {
         var andConstraint = Render(@<button><h1>Test</h1></button>)
             .Should().HaveChildMarkup("<h1>Test</h1>");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByRenderFragment()
     {
         var andConstraint = Render(@<button><h1>Test</h1></button>)
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupIsNull_AndMatchingByString()
     {
         Action aut = () => Render(@<button></button>)
-            .Should().HaveChildMarkup("<h1>Test</h1>");;
+            .Should().HaveChildMarkup("<h1>Test</h1>"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupIsNull_AndMatchingByRenderFragment()
     {
@@ -52,19 +62,19 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupIsNull_AndMatchingByString()
     {
         Action aut = () => Render(@<button></button>)
-            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve");;
+            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupIsNull_AndMatchingByRenderFragment()
     {
@@ -72,19 +82,19 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\" because this is very important to Steve, but found <null>.");
     }
 
     [Fact]
     public void ThrowException_WhenChildMarkupDoesNotMatch_AndMatchingByString()
     {
         Action aut = () => Render(@<button><h2>Test</h2></button>)
-            .Should().HaveChildMarkup("<h1>Test</h1>");;
+            .Should().HaveChildMarkup("<h1>Test</h1>"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenChildMarkupDoesNotMatch_AndMatchingByRenderFragment()
     {
@@ -92,19 +102,19 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\", but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByString()
     {
         Action aut = () => Render(@<button><h2>Test</h2></button>)
-            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve");;
+            .Should().HaveChildMarkup("<h1>Test</h1>", "this is very important to {0}", "Steve"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByRenderFragment()
     {
@@ -112,6 +122,6 @@
             .Should().HaveChildMarkup(@<h1>Test</h1>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
+            .And.Message.Should().Be("Expected IRenderedComponent to have child \"<h1>Test</h1>\" because this is very important to Steve, but found \"<h2>Test</h2>\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveClassShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Theory]
     [InlineData("btn")]
     [InlineData("big")]
@@ -12,16 +12,21 @@
         Render(@<button Class="btn big cta"><h1>Test</h1></button>)
             .Should().HaveClass(expectedClass);
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button Class="btn big cta"><h1>Test</h1></button>)
             .Should().HaveClass("btn");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAnyClass()
     {
@@ -29,9 +34,9 @@
             .Should().HaveClass("btn");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {empty} to contain \"btn\".");
+            .And.Message.Should().Be("Expected element.ClassList {empty} to contain \"btn\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAnyClass_AndShouldIncludeBecauseMessage()
     {
@@ -39,9 +44,9 @@
             .Should().HaveClass("btn", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {empty} to contain \"btn\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected element.ClassList {empty} to contain \"btn\" because this is very important to Steve.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -49,9 +54,9 @@
             .Should().HaveClass("btn");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\".");
+            .And.Message.Should().Be("Expected element.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -59,6 +64,6 @@
             .Should().HaveClass("btn", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected element.ClassList {\"btt\", \"big\", \"cta\"} to contain \"btn\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveDataTestClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveDataTestClassShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button data-test-class="magic-button">Click Me</button>)
             .Should().HaveDataTestClass("magic-button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button data-test-class="magic-button">Click Me</button>)
             .Should().HaveDataTestClass("magic-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveDataTestClass("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"data-test-class\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"data-test-class\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveDataTestClass("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"data-test-class\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"data-test-class\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveDataTestClass("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"data-test-class\" attribute to have value \"magic-button\", but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"data-test-class\" attribute to have value \"magic-button\", but found \"magic-btn\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveDataTestClass("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"data-test-class\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"data-test-class\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveDataTestIdShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveDataTestIdShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button data-test-id="magic-button">Click Me</button>)
             .Should().HaveDataTestId("magic-button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button data-test-id="magic-button">Click Me</button>)
             .Should().HaveDataTestId("magic-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveDataTestId("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"data-test-id\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"data-test-id\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveDataTestId("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"data-test-id\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"data-test-id\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveDataTestId("magic-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"data-test-id\" attribute to have value \"magic-button\", but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"data-test-id\" attribute to have value \"magic-button\", but found \"magic-btn\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveDataTestId("magic-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"data-test-id\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"data-test-id\" attribute to have value \"magic-button\" because this is very important to Steve, but found \"magic-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveHrefShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveHrefShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<a href="https://github.com/srpeirce/fluentassertions.bUnit">Link</a>)
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<a href="https://github.com/srpeirce/fluentassertions.bUnit">Link</a>)
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"href\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"href\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"href\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"href\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\", but found \"#\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\", but found \"#\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveHref("https://github.com/srpeirce/fluentassertions.bUnit", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\" because this is very important to Steve, but found \"#\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"href\" attribute to have value \"https://github.com/srpeirce/fluentassertions.bUnit\" because this is very important to Steve, but found \"#\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveIdShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveIdShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button id="special-button">Click Me</button>)
             .Should().HaveId("special-button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button id="special-button">Click Me</button>)
             .Should().HaveId("special-button");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveId("special-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"id\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"id\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveId("special-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"id\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"id\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveId("special-button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"id\" attribute to have value \"special-button\", but found \"special-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"id\" attribute to have value \"special-button\", but found \"special-btn\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveId("special-button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"id\" attribute to have value \"special-button\" because this is very important to Steve, but found \"special-btn\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"id\" attribute to have value \"special-button\" because this is very important to Steve, but found \"special-btn\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveMarkupShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveMarkupShould.razor
@@ -1,38 +1,48 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed_WhenMatchingByString()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().HaveMarkup("<button><h1>Test</h1></button>");
     }
-    
+
     [Fact]
     public void Succeed_WhenMatchingByRenderFragment()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().HaveMarkup(@<button><h1>Test</h1></button>);
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByString()
     {
         var andConstraint = Render(@<button><h1>Test</h1></button>)
             .Should().HaveMarkup("<button><h1>Test</h1></button>");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ReturnAndConstraint_WhenMatchingByRenderFragment()
     {
         var andConstraint = Render(@<button><h1>Test</h1></button>)
             .Should().HaveMarkup(@<button><h1>Test</h1></button>);
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -42,7 +52,7 @@
             .Should().HaveMarkup("<button><h1>Test</h1></button>");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().BeEquivalentTo("Expected IRenderedFragment markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
+            .And.Message.Should().BeEquivalentTo("Expected IRenderedComponent markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
     }
 
     [Fact]
@@ -52,19 +62,19 @@
             .Should().HaveMarkup(@<button><h1>Test</h1></button>);
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().BeEquivalentTo("Expected IRenderedFragment markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
+            .And.Message.Should().BeEquivalentTo("Expected IRenderedComponent markup \"<button><h1>Test</h1></button>\", but found \"<button><h2>Test</h2></button>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByString()
     {
         Action aut = () => Render(@<button><h2>Test</h2></button>)
-            .Should().HaveMarkup("<button><h1>Test</h1></button>", "this is very important to {0}", "Steve");;
+            .Should().HaveMarkup("<button><h1>Test</h1></button>", "this is very important to {0}", "Steve"); ;
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().BeEquivalentTo("Expected IRenderedFragment markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
+            .And.Message.Should().BeEquivalentTo("Expected IRenderedComponent markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
     }
-    
+
     [Fact]
     public void ThrowException_AndIncludeBecauseMessage_WhenChildMarkupDoesNotMatch_AndMatchingByRenderFragment()
     {
@@ -72,6 +82,6 @@
             .Should().HaveMarkup(@<button><h1>Test</h1></button>, "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().BeEquivalentTo("Expected IRenderedFragment markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
+            .And.Message.Should().BeEquivalentTo("Expected IRenderedComponent markup \"<button><h1>Test</h1></button>\" because this is very important to Steve, but found \"<button><h2>Test</h2></button>\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveRelShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveRelShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Theory]
     [InlineData("nofollow")]
     [InlineData("noopener")]
@@ -11,7 +11,7 @@
         Render(@<a href="#" rel="nofollow noopener">Link</a>)
             .Should().HaveRel(expected);
     }
-    
+
     [Theory]
     [InlineData("nofollow")]
     [InlineData("noopener")]
@@ -20,9 +20,14 @@
         var andConstraint = Render(@<a href="#" rel="nofollow noopener">Link</a>)
             .Should().HaveRel(expected);
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -30,9 +35,9 @@
             .Should().HaveRel("nofollow");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"rel\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"rel\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -40,9 +45,9 @@
             .Should().HaveRel("nofollow", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"rel\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"rel\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -50,9 +55,9 @@
             .Should().HaveRel("noopener");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"rel\" [{\"nofollow\"}] to contain \"noopener\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"rel\" [{\"nofollow\"}] to contain \"noopener\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -60,6 +65,6 @@
             .Should().HaveRel("noopener", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"rel\" [{\"nofollow\"}] to contain \"noopener\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected IRenderedComponent \"rel\" [{\"nofollow\"}] to contain \"noopener\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveSrcShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveSrcShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveSrc("/logo.png");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<img src="/logo.png" alt="Logo">)
             .Should().HaveSrc("/logo.png");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveSrc("/logo.png");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"src\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"src\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveSrc("/logo.png", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"src\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"src\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveSrc("/logo.png");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"src\" attribute to have value \"/logo.png\", but found \"/loog.png\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"src\" attribute to have value \"/logo.png\", but found \"/loog.png\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveSrc("/logo.png", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"src\" attribute to have value \"/logo.png\" because this is very important to Steve, but found \"/loog.png\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"src\" attribute to have value \"/logo.png\" because this is very important to Steve, but found \"/loog.png\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTagShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTagShould.razor
@@ -1,22 +1,27 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().HaveTag("button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button><h1>Test</h1></button>)
             .Should().HaveTag("button");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -26,9 +31,9 @@
             .Should().HaveTag("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"tag\" to be \"button\", but found \"div\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"tag\" to be \"button\", but found \"div\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenTagNotMatchExpected_AndShouldIncludeBecauseMessage()
     {
@@ -36,6 +41,6 @@
             .Should().HaveTag("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"tag\" to be \"button\" because this is very important to Steve, but found \"div\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"tag\" to be \"button\" because this is very important to Steve, but found \"div\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTargetShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTargetShould.razor
@@ -1,34 +1,39 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<a href="#" target="_blank">Link</a>)
             .Should().HaveTarget("_blank");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<a href="#" target="_blank">Link</a>)
             .Should().HaveTarget("_blank");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
-        Action aut = () => Render(@<a href="#" >Link</a>)
+        Action aut = () => Render(@<a href="#">Link</a>)
             .Should().HaveTarget("_blank");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"target\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"target\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveTarget("_blank", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"target\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"target\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveTarget("_blank");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"target\" attribute to have value \"_blank\", but found \"_self\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"target\" attribute to have value \"_blank\", but found \"_self\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveTarget("_blank", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"target\" attribute to have value \"_blank\" because this is very important to Steve, but found \"_self\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"target\" attribute to have value \"_blank\" because this is very important to Steve, but found \"_self\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTitleShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTitleShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<a href="#" title="GitHub Repo">Link</a>)
             .Should().HaveTitle("GitHub Repo");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<a href="#" title="GitHub Repo">Link</a>)
             .Should().HaveTitle("GitHub Repo");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveTitle("GitHub Repo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"title\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"title\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveTitle("GitHub Repo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"title\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"title\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveTitle("GitHub Repo");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"title\" attribute to have value \"GitHub Repo\", but found \"GH Repo\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"title\" attribute to have value \"GitHub Repo\", but found \"GH Repo\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveTitle("GitHub Repo", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"title\" attribute to have value \"GitHub Repo\" because this is very important to Steve, but found \"GH Repo\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"title\" attribute to have value \"GitHub Repo\" because this is very important to Steve, but found \"GH Repo\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/HaveTypeShould.razor
@@ -1,24 +1,29 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button type="button">Click me</button>)
             .Should().HaveType("button");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button type="button">Click me</button>)
             .Should().HaveType("button");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute()
     {
@@ -26,9 +31,9 @@
             .Should().HaveType("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"type\", but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"type\", but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenDoesNotHaveAttribute_AndShouldIncludeBecauseMessage()
     {
@@ -36,9 +41,9 @@
             .Should().HaveType("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment to have attribute \"type\" because this is very important to Steve, but found <null>.");
+            .And.Message.Should().Be("Expected IRenderedComponent to have attribute \"type\" because this is very important to Steve, but found <null>.");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue()
     {
@@ -46,9 +51,9 @@
             .Should().HaveType("button");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"type\" attribute to have value \"button\", but found \"reset\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"type\" attribute to have value \"button\", but found \"reset\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenHasAttributeWithWrongValue_AndShouldIncludeBecauseMessage()
     {
@@ -56,6 +61,6 @@
             .Should().HaveType("button", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected IRenderedFragment \"type\" attribute to have value \"button\" because this is very important to Steve, but found \"reset\".");
+            .And.Message.Should().Be("Expected IRenderedComponent \"type\" attribute to have value \"button\" because this is very important to Steve, but found \"reset\".");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeAssignableToShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeAssignableToShould.razor
@@ -1,15 +1,15 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenAssignable()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().BeAssignableTo<IDisposable>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotAssignable()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeNullShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeNullShould.razor
@@ -1,16 +1,16 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenNull()
     {
-        IRenderedFragment f = null;
-        
+        var f = (IRenderedComponent<Microsoft.AspNetCore.Components.IComponent>)null;
+
         f.Should().BeNull();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotNull()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeOfTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeOfTypeShould.razor
@@ -1,22 +1,22 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
-    public void SucceedWhenComparingToSameReference()
+    public void SucceedWhenOfType()
     {
         var renderedFragment = Render(@<img src="/logo.png" alt="Logo">);
-        
+
         renderedFragment
-            .Should().BeSameAs(renderedFragment);
+            .Should().BeOfType(renderedFragment.GetType());
     }
 
     [Fact]
-    public void ThrowExceptionWhenComparingToAnotherReference()
+    public void ThrowExceptionWhenNotOfType()
     {
         Action aut = () => Render(@<img src="/logo.png" alt="Logo">)
-            .Should().BeSameAs(Render(@<img src="/logo.png" alt="Logo">));
+            .Should().BeOfType<object>();
 
         aut.Should().Throw<XunitException>();
     }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeSameAsShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/BeSameAsShould.razor
@@ -1,22 +1,22 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
-    public void SucceedWhenOfType()
+    public void SucceedWhenComparingToSameReference()
     {
         var renderedFragment = Render(@<img src="/logo.png" alt="Logo">);
-        
+
         renderedFragment
-            .Should().BeOfType(renderedFragment.GetType());
+            .Should().BeSameAs(renderedFragment);
     }
-    
+
     [Fact]
-    public void ThrowExceptionWhenNotOfType()
+    public void ThrowExceptionWhenComparingToAnotherReference()
     {
         Action aut = () => Render(@<img src="/logo.png" alt="Logo">)
-            .Should().BeOfType<IRenderedFragment>();
+            .Should().BeSameAs(Render(@<img src="/logo.png" alt="Logo">));
 
         aut.Should().Throw<XunitException>();
     }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/MatchShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/MatchShould.razor
@@ -1,15 +1,15 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenMatches()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().Match(rf => rf.Markup.Contains("img"));
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenDoesNotMatch()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeAssignableToShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeAssignableToShould.razor
@@ -1,15 +1,15 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenAssignable()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().NotBeAssignableTo<string>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotAssignable()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeNullShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeNullShould.razor
@@ -1,24 +1,24 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenNotNull()
     {
         Render(@<img src="/logo.png" alt="Logo">)
             .Should().NotBeNull();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNull()
     {
         Action aut = () =>
         {
-            IRenderedFragment f = null;
+            var f = (IRenderedComponent<Microsoft.AspNetCore.Components.IComponent>)null;
             f.Should().NotBeNull();
         };
-        
+
         aut.Should().Throw<XunitException>();
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeOfTypeShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeOfTypeShould.razor
@@ -1,15 +1,15 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenOfType()
     {
         Render(@<img src="/logo.png" alt="Logo">)
-            .Should().NotBeOfType<IRenderedFragment>();
+            .Should().NotBeOfType<object>();
     }
-    
+
     [Fact]
     public void ThrowExceptionWhenNotOfType()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeSameAsShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/NotBeSameAsShould.razor
@@ -1,8 +1,8 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void SucceedWhenComparingToAnotherReference()
     {

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/Readme.md
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/Readme.md
@@ -1,0 +1,3 @@
+> 💡 Note: The functionality that we test here we get from `RenderedFragmentAssertions` inheriting from `ReferenceTypeAssertions<IRenderedComponent<TComponent>, TAssertions>`.
+> 
+> I decided to add some basic tests to explore their API and check it behaves as I expect.

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/SubjectShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/Inherited/SubjectShould.razor
@@ -1,14 +1,14 @@
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void BeSameAsRenderedFragment()
     {
         var renderedFragment = Render(@<img src="/logo.png" alt="Logo">);
-        
+
         var subject = renderedFragment.Should().Subject;
 
-        subject.Should().BeAssignableTo<IRenderedFragment>().And.BeSameAs(renderedFragment);
+        subject.Should().BeAssignableTo(renderedFragment.GetType()).And.BeSameAs(renderedFragment);
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/NotHaveClassShould.razor
+++ b/FluentAssertions.BUnit.Tests/RenderedComponentAssertions/NotHaveClassShould.razor
@@ -1,29 +1,34 @@
 @using Xunit.Sdk
-@inherits Bunit.TestContext
+@inherits Bunit.BunitContext
 
 @code {
-    
+
     [Fact]
     public void Succeed()
     {
         Render(@<button class="btn big cta"><h1>Test</h1></button>)
             .Should().NotHaveClass("btn-large");
     }
-    
+
     [Fact]
     public void Succeed_WhenNoClassInMarkup()
     {
         Render(@<button><h1>Test</h1></button>)
             .Should().NotHaveClass("btn-large");
     }
-    
+
     [Fact]
     public void ReturnAndConstraint()
     {
         var andConstraint = Render(@<button class="btn big cta"><h1>Test</h1></button>)
             .Should().NotHaveClass("btn-large");
 
-        andConstraint.Should().BeOfType<AndConstraint<RenderedFragmentAssertions>>();
+        var constraintType = andConstraint.GetType();
+        constraintType.IsGenericType.Should().BeTrue();
+        constraintType.GetGenericTypeDefinition().Should().Be(typeof(AndConstraint<>));
+        var assertionType = constraintType.GetGenericArguments()[0];
+        assertionType.IsGenericType.Should().BeTrue();
+        assertionType.GetGenericTypeDefinition().Should().Be(typeof(RenderedFragmentAssertions<>));
     }
 
     [Fact]
@@ -33,9 +38,9 @@
             .Should().NotHaveClass("btn-large");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\".");
+            .And.Message.Should().Be("Expected element.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\".");
     }
-    
+
     [Fact]
     public void ThrowException_WhenClassIsFound_AndShouldIncludeBecauseMessage()
     {
@@ -43,6 +48,6 @@
             .Should().NotHaveClass("btn-large", "this is very important to {0}", "Steve");
 
         aut.Should().Throw<XunitException>()
-            .And.UserMessage.Should().Be("Expected element.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\" because this is very important to Steve.");
+            .And.Message.Should().Be("Expected element.ClassList {\"btn\", \"btn-large\", \"big\", \"cta\"} to not contain \"btn-large\" because this is very important to Steve.");
     }
 }

--- a/FluentAssertions.BUnit.Tests/RenderedFragmentAssertions/Inherited/Readme.md
+++ b/FluentAssertions.BUnit.Tests/RenderedFragmentAssertions/Inherited/Readme.md
@@ -1,3 +1,0 @@
-> 💡 Note: The functionality that we test here we get from `RenderedFragmentAssertions` inheriting from `ReferenceTypeAssertions<IRenderedFragment, TAssertions>`.
-> 
-> I decided to add some basic tests to explore their API and check it behaves as I expect.

--- a/FluentAssertions.BUnit.Tests/_Imports.razor
+++ b/FluentAssertions.BUnit.Tests/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @using Microsoft.Extensions.DependencyInjection

--- a/FluentAssertions.BUnit/AssertionExtensions.cs
+++ b/FluentAssertions.BUnit/AssertionExtensions.cs
@@ -1,18 +1,18 @@
 ﻿using AngleSharp.Dom;
 using Bunit;
 
-namespace FluentAssertions.BUnit
+namespace FluentAssertions.BUnit;
+
+public static class AssertionExtensions
 {
-    public static class AssertionExtensions
+    public static RenderedFragmentAssertions<TComponent> Should<TComponent>(this IRenderedComponent<TComponent> actualValue)
+        where TComponent : Microsoft.AspNetCore.Components.IComponent
     {
-        public static RenderedFragmentAssertions Should(this IRenderedFragment actualValue)
-        {
-            return new RenderedFragmentAssertions(actualValue);
-        }
-        
-        public static ElementAssertions Should(this IElement actualValue)
-        {
-            return new ElementAssertions(actualValue);
-        }
+        return new RenderedFragmentAssertions<TComponent>(actualValue);
+    }
+    
+    public static ElementAssertions Should(this IElement actualValue)
+    {
+        return new ElementAssertions(actualValue);
     }
 }

--- a/FluentAssertions.BUnit/BUnitExtensions.cs
+++ b/FluentAssertions.BUnit/BUnitExtensions.cs
@@ -1,21 +1,25 @@
-﻿using AngleSharp.Dom;
+﻿using System.Collections.Generic;
+using AngleSharp.Dom;
 using Bunit;
 
-namespace FluentAssertions.BUnit
+namespace FluentAssertions.BUnit;
+
+public static class BUnitExtensions
 {
-    public static class BUnitExtensions
-    {
-        public static IElement FindByDataTestId(this IRenderedFragment component, string dataTestId)
-            => component.Find($"[data-test-id='{dataTestId}']");
-        
-        public static IElement FindByDataTestClass(this IRenderedFragment component, string dataTestClass)
-            => component.Find($"[data-test-class='{dataTestClass}']");
+    public static IElement FindByDataTestId<TComponent>(this IRenderedComponent<TComponent> component, string dataTestId)
+        where TComponent : Microsoft.AspNetCore.Components.IComponent
+        => component.Find($"[data-test-id='{dataTestId}']");
+    
+    public static IElement FindByDataTestClass<TComponent>(this IRenderedComponent<TComponent> component, string dataTestClass)
+        where TComponent : Microsoft.AspNetCore.Components.IComponent
+        => component.Find($"[data-test-class='{dataTestClass}']");
 
-        public static IRefreshableElementCollection<IElement> FindAllByDataTestClass(this IRenderedFragment component,
-            string dataTestClass)
-            => component.FindAll($"[data-test-class='{dataTestClass}']");
+    public static IReadOnlyList<IElement> FindAllByDataTestClass<TComponent>(this IRenderedComponent<TComponent> component,
+        string dataTestClass)
+        where TComponent : Microsoft.AspNetCore.Components.IComponent
+        => component.FindAll($"[data-test-class='{dataTestClass}']");
 
-        public static IElement AsElement(this IRenderedFragment component)
-            => component.Nodes.QuerySelector("*");
-    }
+    public static IElement AsElement<TComponent>(this IRenderedComponent<TComponent> component)
+        where TComponent : Microsoft.AspNetCore.Components.IComponent
+        => component.Nodes.QuerySelector("*");
 }

--- a/FluentAssertions.BUnit/ElementAssertions.cs
+++ b/FluentAssertions.BUnit/ElementAssertions.cs
@@ -1,114 +1,82 @@
-﻿using System;
-using System.Linq;
+﻿using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Components;
+using System;
+using System.Linq;
 
-namespace FluentAssertions.BUnit
+namespace FluentAssertions.BUnit;
+
+/// <summary>
+/// Contains a number of methods to assert that an <see cref="IElement"/> is in the expected state.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="RenderedFragmentAssertions"/> class.
+/// </remarks>
+public class ElementAssertions(IElement value) : ElementAssertions<ElementAssertions>(value)
 {
+}
+
+public class ElementAssertions<TAssertions>(IElement value) : ReferenceTypeAssertions<IElement, TAssertions>(value) 
+    where TAssertions : ElementAssertions<TAssertions>
+{
+    private readonly BunitContext _testContext = new BunitContext();
+
     /// <summary>
-    /// Contains a number of methods to assert that a <see cref="IRenderedFragment"/> is in the expected state.
+    /// Returns the type of the subject the assertion applies on.
     /// </summary>
-    public class ElementAssertions : ElementAssertions<ElementAssertions>
+    protected override string Identifier => "IElement";
+
+    public AndConstraint<TAssertions> HaveChildMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RenderedFragmentAssertions"/> class.
-        /// </summary>
-        public ElementAssertions(IElement value)
-            : base(value)
+        var child = Subject.FirstChild;
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(child is not null)
+            .FailWith("Expected {context:IElement} to have child {0}{reason}, but found <null>.", _testContext.Render(expected).Markup);
+    
+        if (success)
         {
+            bool doesMarkupMatch;
+    
+            try
+            {
+                child!.MarkupMatches(expected);
+                doesMarkupMatch = true;
+            }
+            catch
+            {
+                doesMarkupMatch = false;
+            }
+            
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(doesMarkupMatch)
+                .FailWith("Expected {context:IElement} to have child {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, child is IElement childElement ? Regex.Replace(childElement.OuterHtml ?? "", @">\s+<", "><").Trim() : child?.ToString() ?? "<null>");
         }
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
     }
-
-    public class ElementAssertions<TAssertions> : ReferenceTypeAssertions<IElement, TAssertions> 
-        where TAssertions : ElementAssertions<TAssertions>
+    
+    public AndConstraint<TAssertions> HaveChildMarkup(string expected, string because = "", params object[] becauseArgs)
     {
-        private readonly TestContext _testContext;
-
-        /// <summary>
-        /// Returns the type of the subject the assertion applies on.
-        /// </summary>
-        protected override string Identifier => "IRenderedFragment";
+        var child = Subject.FirstChild;
         
-        public ElementAssertions(IElement value)
-            : base(value)
-        {
-            _testContext = new TestContext();
-        }
-        
-        public AndConstraint<TAssertions> HaveChildMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
-        {
-            var child = Subject.FirstChild;
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(child is not null)
-                .FailWith("Expected {context:IElement} to have child {0}{reason}, but found <null>.", _testContext.Render(expected).Markup);
-        
-            if (success)
-            {
-                bool doesMarkupMatch;
-        
-                try
-                {
-                    child!.MarkupMatches(expected);
-                    doesMarkupMatch = true;
-                }
-                catch
-                {
-                    doesMarkupMatch = false;
-                }
-                
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(doesMarkupMatch)
-                    .FailWith("Expected {context:IElement} to have child {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, child!.ToMarkup().TrimStart());
-            }
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveChildMarkup(string expected, string because = "", params object[] becauseArgs)
-        {
-            var child = Subject.FirstChild;
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(child is not null)
-                .FailWith("Expected {context:IElement} to have child {0}{reason}, but found <null>.", expected);
-        
-            if (success)
-            {
-                bool doesMarkupMatch;
-        
-                try
-                {
-                    child!.MarkupMatches(expected);
-                    doesMarkupMatch = true;
-                }
-                catch
-                {
-                    doesMarkupMatch = false;
-                }
-                
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(doesMarkupMatch)
-                    .FailWith("Expected {context:IElement} to have child {0}{reason}, but found {1}.", expected, child!.ToMarkup().TrimStart());
-            }
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(child is not null)
+            .FailWith("Expected {context:IElement} to have child {0}{reason}, but found <null>.", expected);
+    
+        if (success)
         {
             bool doesMarkupMatch;
-        
+    
             try
             {
-                Subject.MarkupMatches(expected);
+                child!.MarkupMatches(expected);
                 doesMarkupMatch = true;
             }
             catch
@@ -119,128 +87,150 @@ namespace FluentAssertions.BUnit
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(doesMarkupMatch)
-                .FailWith("Expected {context:IElement} markup {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, Subject.ToMarkup());
-                return new AndConstraint<TAssertions>((TAssertions)this);
+                .FailWith("Expected {context:IElement} to have child {0}{reason}, but found {1}.", expected, child is IElement childElement ? Regex.Replace(childElement.OuterHtml ?? "", @">\s+<", "><").Trim() : child?.ToString() ?? "<null>");
+        }
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
+    {
+        bool doesMarkupMatch;
+    
+        try
+        {
+            Subject.MarkupMatches(expected);
+            doesMarkupMatch = true;
+        }
+        catch
+        {
+            doesMarkupMatch = false;
         }
         
-        public AndConstraint<TAssertions> HaveMarkup(string expected, string because = "", params object[] becauseArgs)
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(doesMarkupMatch)
+            .FailWith("Expected {context:IElement} markup {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, Regex.Replace(Subject.OuterHtml, @">\s+<", "><").Trim());
+            return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveMarkup(string expected, string because = "", params object[] becauseArgs)
+    {
+        bool doesMarkupMatch;
+    
+        try
         {
-            bool doesMarkupMatch;
+            Subject.MarkupMatches(expected);
+            doesMarkupMatch = true;
+        }
+        catch
+        {
+            doesMarkupMatch = false;
+        }
         
-            try
-            {
-                Subject.MarkupMatches(expected);
-                doesMarkupMatch = true;
-            }
-            catch
-            {
-                doesMarkupMatch = false;
-            }
-            
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(doesMarkupMatch)
+            .FailWith("Expected {context:IElement} markup {0}{reason}, but found {1}.", expected, Regex.Replace(Subject.OuterHtml, @">\s+<", "><").Trim());
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> NotHaveClass(string expected, string because = "", params object[] becauseArgs)
+    {
+        Subject.ClassList.Should().NotContain(expected, because, becauseArgs);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveClass(string expected, string because = "", params object[] becauseArgs)
+    {
+        Subject.ClassList.Should().Contain(expected, because, becauseArgs);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveRel(string expected, string because = "", params object[] becauseArgs)
+    {
+        var attribute = Subject.Attributes["rel"];
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(attribute is not null)
+            .FailWith("Expected {context:IElement} to have attribute {0}{reason}, but found <null>.", "rel");
+    
+        if (success)
+        {
+            var collection = attribute!.Value.Split(" ").ToList();
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(doesMarkupMatch)
-                .FailWith("Expected {context:IElement} markup {0}{reason}, but found {1}.", expected, Subject.ToMarkup());
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
+                .ForCondition(attribute!.Value.Split(" ").Contains(expected))
+                .FailWith("Expected {context:IElement} {0} [{1}] to contain {2}{reason}.", "rel", collection, expected);
         }
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveTag(string expected, string because = "", params object[] becauseArgs)
+    {
+        var tag = Subject.LocalName;
         
-        public AndConstraint<TAssertions> NotHaveClass(string expected, string because = "", params object[] becauseArgs)
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(tag.Equals(expected, StringComparison.InvariantCulture))
+            .FailWith("Expected {context:IElement} {0} to be {1}{reason}, but found {2}.", "tag", expected, tag);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveAltText(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("alt", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveAriaLabel(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("aria-label", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveDataTestClass(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("data-test-class", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveDataTestId(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("data-test-id", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveHref(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("href", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveId(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("id", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveSrc(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("src", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveTarget(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("target", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveTitle(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("title", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveType(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("type", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveAttribute(string attributeName, string expectedValue, string because = "", params object[] becauseArgs)
+    {
+        var attribute = Subject.Attributes[attributeName];
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(attribute is not null)
+            .FailWith("Expected {context:IElement} to have attribute {0}{reason}, but found <null>.", attributeName);
+        
+        if (success)
         {
-            Subject.ClassList.Should().NotContain(expected, because, becauseArgs);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveClass(string expected, string because = "", params object[] becauseArgs)
-        {
-            Subject.ClassList.Should().Contain(expected, because, becauseArgs);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveRel(string expected, string because = "", params object[] becauseArgs)
-        {
-            var attribute = Subject.Attributes["rel"];
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(attribute is not null)
-                .FailWith("Expected {context:IElement} to have attribute {0}{reason}, but found <null>.", "rel");
-        
-            if (success)
-            {
-                var collection = attribute!.Value.Split(" ").ToList();
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(attribute!.Value.Split(" ").Contains(expected))
-                    .FailWith("Expected {context:IElement} {0} [{1}] to contain {2}{reason}.", "rel", collection, expected);
-            }
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveTag(string expected, string because = "", params object[] becauseArgs)
-        {
-            var tag = Subject.LocalName;
-            
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(tag.Equals(expected, StringComparison.InvariantCulture))
-                .FailWith("Expected {context:IElement} {0} to be {1}{reason}, but found {2}.", "tag", expected, tag);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
+                .ForCondition(attribute!.Value == expectedValue)
+                .FailWith("Expected {context:IElement} {0} attribute to have value {1}{reason}" +
+                          ", but found {2}.", attributeName, expectedValue, attribute.Value);
         }
-        
-        public AndConstraint<TAssertions> HaveAltText(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("alt", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveAriaLabel(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("aria-label", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveDataTestClass(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("data-test-class", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveDataTestId(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("data-test-id", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveHref(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("href", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveId(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("id", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveSrc(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("src", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveTarget(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("target", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveTitle(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("title", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveType(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("type", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveAttribute(string attributeName, string expectedValue, string because = "", params object[] becauseArgs)
-        {
-            var attribute = Subject.Attributes[attributeName];
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(attribute is not null)
-                .FailWith("Expected {context:IElement} to have attribute {0}{reason}, but found <null>.", attributeName);
-            
-            if (success)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(attribute!.Value == expectedValue)
-                    .FailWith("Expected {context:IElement} {0} attribute to have value {1}{reason}" +
-                              ", but found {2}.", attributeName, expectedValue, attribute.Value);
-            }
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }

--- a/FluentAssertions.BUnit/FluentAssertions.BUnit.csproj
+++ b/FluentAssertions.BUnit/FluentAssertions.BUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <PackageTags>Blazor;BUnit;FluentAssertions</PackageTags>
@@ -15,9 +15,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AngleSharp" Version="0.16.0" />
-      <PackageReference Include="bunit" Version="1.2.49" />
-      <PackageReference Include="FluentAssertions" Version="6.0.0" />
+      <PackageReference Include="AngleSharp" Version="1.4.0" />
+      <PackageReference Include="bunit" Version="2.0.66" />
+      <PackageReference Include="FluentAssertions" Version="7.2.0" />
     </ItemGroup>
 
 </Project>

--- a/FluentAssertions.BUnit/RenderedFragmentAssertions.cs
+++ b/FluentAssertions.BUnit/RenderedFragmentAssertions.cs
@@ -1,115 +1,86 @@
 ﻿using System;
 using System.Linq;
+using System.Text.RegularExpressions;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Components;
 
-namespace FluentAssertions.BUnit
+namespace FluentAssertions.BUnit;
+
+/// <summary>
+/// Contains a number of methods to assert that a <see cref="IRenderedComponent{TComponent}"/> is in the expected state.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="RenderedFragmentAssertions"/> class.
+/// </remarks>
+public class RenderedFragmentAssertions<TComponent>(IRenderedComponent<TComponent> value) : RenderedFragmentAssertions<RenderedFragmentAssertions<TComponent>, TComponent>(value)
+    where TComponent : IComponent
 {
+}
+
+public class RenderedFragmentAssertions<TAssertions, TComponent>(IRenderedComponent<TComponent> value) : ReferenceTypeAssertions<IRenderedComponent<TComponent>, TAssertions>(value) 
+    where TAssertions : RenderedFragmentAssertions<TAssertions, TComponent>
+    where TComponent : IComponent
+{
+    private readonly BunitContext _testContext = new BunitContext();
+
     /// <summary>
-    /// Contains a number of methods to assert that a <see cref="IRenderedFragment"/> is in the expected state.
+    /// Returns the type of the subject the assertion applies on.
     /// </summary>
-    public class RenderedFragmentAssertions : RenderedFragmentAssertions<RenderedFragmentAssertions>
+    protected override string Identifier => "IRenderedComponent";
+
+    public AndConstraint<TAssertions> HaveChildMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RenderedFragmentAssertions"/> class.
-        /// </summary>
-        public RenderedFragmentAssertions(IRenderedFragment value)
-            : base(value)
+        var element = Subject.AsElement();
+        var child = element.FirstChild;
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(child is not null)
+            .FailWith("Expected {context:IRenderedComponent} to have child {0}{reason}, but found <null>.", _testContext.Render(expected).Markup);
+
+        if (success)
         {
+            bool doesMarkupMatch;
+
+            try
+            {
+                child!.MarkupMatches(expected);
+                doesMarkupMatch = true;
+            }
+            catch
+            {
+                doesMarkupMatch = false;
+            }
+            
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(doesMarkupMatch)
+                .FailWith("Expected {context:IRenderedComponent} to have child {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, child is IElement childElement ? Regex.Replace(childElement.OuterHtml ?? "", @">\s+<", "><").Trim() : child?.ToString() ?? "<null>");
         }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
     }
 
-    public class RenderedFragmentAssertions<TAssertions> : ReferenceTypeAssertions<IRenderedFragment, TAssertions> 
-        where TAssertions : RenderedFragmentAssertions<TAssertions>
+    public AndConstraint<TAssertions> HaveChildMarkup(string expected, string because = "", params object[] becauseArgs)
     {
-        private readonly TestContext _testContext;
-
-        /// <summary>
-        /// Returns the type of the subject the assertion applies on.
-        /// </summary>
-        protected override string Identifier => "IRenderedFragment";
+        var element = Subject.AsElement();
+        var child = element.FirstChild;
         
-        public RenderedFragmentAssertions(IRenderedFragment value)
-            : base(value)
-        {
-            _testContext = new TestContext();
-        }
-        
-        public AndConstraint<TAssertions> HaveChildMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            var child = element.FirstChild;
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(child is not null)
-                .FailWith("Expected {context:IRenderedFragment} to have child {0}{reason}, but found <null>.", _testContext.Render(expected).Markup);
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(child is not null)
+            .FailWith("Expected {context:IRenderedComponent} to have child {0}{reason}, but found <null>.", expected);
 
-            if (success)
-            {
-                bool doesMarkupMatch;
-
-                try
-                {
-                    child!.MarkupMatches(expected);
-                    doesMarkupMatch = true;
-                }
-                catch
-                {
-                    doesMarkupMatch = false;
-                }
-                
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(doesMarkupMatch)
-                    .FailWith("Expected {context:IRenderedFragment} to have child {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, child!.ToMarkup().TrimStart());
-            }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        public AndConstraint<TAssertions> HaveChildMarkup(string expected, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            var child = element.FirstChild;
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(child is not null)
-                .FailWith("Expected {context:IRenderedFragment} to have child {0}{reason}, but found <null>.", expected);
-
-            if (success)
-            {
-                bool doesMarkupMatch;
-
-                try
-                {
-                    child!.MarkupMatches(expected);
-                    doesMarkupMatch = true;
-                }
-                catch
-                {
-                    doesMarkupMatch = false;
-                }
-                
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(doesMarkupMatch)
-                    .FailWith("Expected {context:IRenderedFragment} to have child {0}{reason}, but found {1}.", expected, child!.ToMarkup().TrimStart());
-            }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
+        if (success)
         {
             bool doesMarkupMatch;
-        
+
             try
             {
-                Subject.MarkupMatches(expected);
+                child!.MarkupMatches(expected);
                 doesMarkupMatch = true;
             }
             catch
@@ -120,133 +91,155 @@ namespace FluentAssertions.BUnit
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(doesMarkupMatch)
-                .FailWith("Expected {context:IRenderedFragment} markup {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, Subject.Markup);
-            return new AndConstraint<TAssertions>((TAssertions)this);
+                .FailWith("Expected {context:IRenderedComponent} to have child {0}{reason}, but found {1}.", expected, child is IElement childElement ? Regex.Replace(childElement.OuterHtml ?? "", @">\s+<", "><").Trim() : child?.ToString() ?? "<null>");
+        }
+
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveMarkup(RenderFragment expected, string because = "", params object[] becauseArgs)
+    {
+        bool doesMarkupMatch;
+    
+        try
+        {
+            Subject.MarkupMatches(expected);
+            doesMarkupMatch = true;
+        }
+        catch
+        {
+            doesMarkupMatch = false;
         }
         
-        public AndConstraint<TAssertions> HaveMarkup(string expected, string because = "", params object[] becauseArgs)
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(doesMarkupMatch)
+            .FailWith("Expected {context:IRenderedComponent} markup {0}{reason}, but found {1}.", _testContext.Render(expected).Markup, Subject.Markup);
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveMarkup(string expected, string because = "", params object[] becauseArgs)
+    {
+        bool doesMarkupMatch;
+    
+        try
         {
-            bool doesMarkupMatch;
+            Subject.MarkupMatches(expected);
+            doesMarkupMatch = true;
+        }
+        catch
+        {
+            doesMarkupMatch = false;
+        }
         
-            try
-            {
-                Subject.MarkupMatches(expected);
-                doesMarkupMatch = true;
-            }
-            catch
-            {
-                doesMarkupMatch = false;
-            }
-            
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(doesMarkupMatch)
+            .FailWith("Expected {context:IRenderedComponent} markup {0}{reason}, but found {1}.", expected, Subject.Markup);
+    
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> NotHaveClass(string expected, string because = "", params object[] becauseArgs)
+    {
+        var element = Subject.AsElement();
+        element.ClassList.Should().NotContain(expected, because, becauseArgs);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveClass(string expected, string because = "", params object[] becauseArgs)
+    {
+        var element = Subject.AsElement();
+        element.ClassList.Should().Contain(expected, because, becauseArgs);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveRel(string expected, string because = "", params object[] becauseArgs)
+    {
+        var element = Subject.AsElement();
+        var attribute = element.Attributes["rel"];
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(attribute is not null)
+            .FailWith("Expected {context:IRenderedComponent} to have attribute {0}{reason}, but found <null>.", "rel");
+
+        if (success)
+        {
+            var collection = attribute!.Value.Split(" ").ToList();
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(doesMarkupMatch)
-                .FailWith("Expected {context:IRenderedFragment} markup {0}{reason}, but found {1}.", expected, Subject.Markup);
-        
-            return new AndConstraint<TAssertions>((TAssertions)this);
+                .ForCondition(attribute!.Value.Split(" ").Contains(expected))
+                .FailWith("Expected {context:IRenderedComponent} {0} [{1}] to contain {2}{reason}.", "rel", collection, expected);
         }
-        
-        public AndConstraint<TAssertions> NotHaveClass(string expected, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            element.ClassList.Should().NotContain(expected, because, becauseArgs);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveClass(string expected, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            element.ClassList.Should().Contain(expected, because, becauseArgs);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-        
-        public AndConstraint<TAssertions> HaveRel(string expected, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            var attribute = element.Attributes["rel"];
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(attribute is not null)
-                .FailWith("Expected {context:IRenderedFragment} to have attribute {0}{reason}, but found <null>.", "rel");
 
-            if (success)
-            {
-                var collection = attribute!.Value.Split(" ").ToList();
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(attribute!.Value.Split(" ").Contains(expected))
-                    .FailWith("Expected {context:IRenderedFragment} {0} [{1}] to contain {2}{reason}.", "rel", collection, expected);
-            }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+    
+    public AndConstraint<TAssertions> HaveTag(string expected, string because = "", params object[] becauseArgs)
+    {
+        var element = Subject.AsElement();
+        var tag = element.LocalName;
         
-        public AndConstraint<TAssertions> HaveTag(string expected, string because = "", params object[] becauseArgs)
+        Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(tag.Equals(expected, StringComparison.InvariantCulture))
+            .FailWith("Expected {context:IRenderedComponent} {0} to be {1}{reason}, but found {2}.", "tag", expected, tag);
+        
+        return new AndConstraint<TAssertions>((TAssertions)this);
+    }
+
+    public AndConstraint<TAssertions> HaveAltText(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("alt", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveAriaLabel(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("aria-label", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveDataTestClass(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("data-test-class", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveDataTestId(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("data-test-id", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveHref(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("href", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveId(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("id", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveSrc(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("src", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveTarget(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("target", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveTitle(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("title", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveType(string expected, string because = "", params object[] becauseArgs) 
+        => HaveAttribute("type", expected, because, becauseArgs);
+    
+    public AndConstraint<TAssertions> HaveAttribute(string attributeName, string expectedValue, string because = "", params object[] becauseArgs)
+    {
+        var element = Subject.AsElement();
+        var attribute = element.Attributes[attributeName];
+        
+        bool success = Execute.Assertion
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(attribute is not null)
+            .FailWith("Expected {context:IRenderedComponent} to have attribute {0}{reason}, but found <null>.", attributeName);
+        
+        if (success)
         {
-            var element = Subject.AsElement();
-            var tag = element.LocalName;
-            
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(tag.Equals(expected, StringComparison.InvariantCulture))
-                .FailWith("Expected {context:IRenderedFragment} {0} to be {1}{reason}, but found {2}.", "tag", expected, tag);
-            
-            return new AndConstraint<TAssertions>((TAssertions)this);
+                .ForCondition(attribute!.Value == expectedValue)
+                .FailWith("Expected {context:IRenderedComponent} {0} attribute to have value {1}{reason}" +
+                          ", but found {2}.", attributeName, expectedValue, attribute.Value);
         }
 
-        public AndConstraint<TAssertions> HaveAltText(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("alt", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveAriaLabel(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("aria-label", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveDataTestClass(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("data-test-class", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveDataTestId(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("data-test-id", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveHref(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("href", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveId(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("id", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveSrc(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("src", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveTarget(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("target", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveTitle(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("title", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveType(string expected, string because = "", params object[] becauseArgs) 
-            => HaveAttribute("type", expected, because, becauseArgs);
-        
-        public AndConstraint<TAssertions> HaveAttribute(string attributeName, string expectedValue, string because = "", params object[] becauseArgs)
-        {
-            var element = Subject.AsElement();
-            var attribute = element.Attributes[attributeName];
-            
-            bool success = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(attribute is not null)
-                .FailWith("Expected {context:IRenderedFragment} to have attribute {0}{reason}, but found <null>.", attributeName);
-            
-            if (success)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(attribute!.Value == expectedValue)
-                    .FailWith("Expected {context:IRenderedFragment} {0} attribute to have value {1}{reason}" +
-                              ", but found {2}.", attributeName, expectedValue, attribute.Value);
-            }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
+        return new AndConstraint<TAssertions>((TAssertions)this);
     }
 }


### PR DESCRIPTION
Updated to .NET 10
In doing so updated to BUnit2.x and AngleSharp 1.x

The `xxxAndConstraint` tests, I did accept a co-pilot suggestion on so a sanity check on those would be appreciated 🙏🏻 

@srpeirce  if you do choose to accept this, probably want to bump your Major version, it looks like a repo secret so I can't do that for you 😁 

**Build and Compatibility Updates:**
- Updated the GitHub Actions workflow in `.github/workflows/dotnet.yml` to use .NET 10.0.x instead of 5.0.x, ensuring tests and builds run on the latest .NET version. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L26-R26) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L46-R46)
- Changed test files to inherit from `Bunit.BunitContext` instead of `Bunit.TestContext` for improved compatibility with the latest bUnit versions. [[1]](diffhunk://#diff-210a671527e3611941779757be1c2b4bfe6a9071aca090cc1be2cb2e754a8dc9L1-R1) [[2]](diffhunk://#diff-1aec7df5a5d74e855ec8d2dfa9ea072177270a881da528d9cc5c75b2ac62dde0L1-R1) [[3]](diffhunk://#diff-400a3f8ec9689d75eecf71aa90aaa64ba5866ab387e24d9b1a864fa3c721e6d6L1-R1) [[4]](diffhunk://#diff-6cfb912586504b1f3b5805ce145521f46986e0510f7cb56d3d575ac371d50a67L1-R1) [[5]](diffhunk://#diff-2117126ad383b67500d92d919f4b6aedba18d599e283468cae18a1f780e8066bL1-R1) [[6]](diffhunk://#diff-1f5a3af526bf9450230a1c74607220d3f4e5cbe3dabf748413013b775cdfb6b2L1-R1) [[7]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL2-R2) [[8]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL2-R2) [[9]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL2-R2) [[10]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L2-R2)

**Test Assertion Improvements:**
- Replaced `BeOfType<T>()` assertions with more robust runtime type checks using `GetType()`, `IsGenericType`, and `GetGenericTypeDefinition()` to ensure the correct assertion types are used, especially for generic types. [[1]](diffhunk://#diff-210a671527e3611941779757be1c2b4bfe6a9071aca090cc1be2cb2e754a8dc9L13-R13) [[2]](diffhunk://#diff-1aec7df5a5d74e855ec8d2dfa9ea072177270a881da528d9cc5c75b2ac62dde0L12-R13) [[3]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL21-R24) [[4]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL21-R24) [[5]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL21-R24) [[6]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L29-R32) [[7]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L39-R45)
- Updated exception assertions to check the `Message` property instead of the deprecated `UserMessage` property, ensuring accurate validation of thrown exception messages. [[1]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL32-R35) [[2]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL43-R46) [[3]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL54-R57) [[4]](diffhunk://#diff-cfda705cbcef4c305529f928376504ce1b59199855394374f93a196d26b8504aL65-R68) [[5]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL32-R35) [[6]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL43-R46) [[7]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL54-R57) [[8]](diffhunk://#diff-a1e3b6fae0722985fd0948d535e313f28e87d9bf92776452154040becd5fb58eL65-R68) [[9]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL32-R35) [[10]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL43-R46) [[11]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL54-R57) [[12]](diffhunk://#diff-a0a348c68f43c244f2453b8cb720fa09671a4c9a17c21004b76e4c4df20e59fcL65-R68) [[13]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L50-R56) [[14]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L61-R67) [[15]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L72-R78) [[16]](diffhunk://#diff-6733a00fda89dc8c1b8814b5a19e5c6aa11e82ef1195b2bf92ea4446805d0577L83-R89)